### PR TITLE
Image name inconsistent with index.docker.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ To build the image from source execute:
 
 	git clone git@github.com:tiagoboldt/sharelatex-docker.git
 	cd sharelatex-docker
-	docker build -t tiagoboldt/sharelatex .
+	docker build -t tiagoboldt/sharelatex-docker:sharelatex .
 
 ## Execution
 
 To start the instance execute: 
 	
-	docker run -d -p 3000:3000 tiagoboldt/sharelatex sharelatex.sh
+	docker run -d -p 3000:3000 tiagoboldt/sharelatex-docker:sharelatex sharelatex.sh
 	
 It will be available on http://localhost:3000. Files will be kept in the user_files folder and database on db folder. 


### PR DESCRIPTION
Currently we build tiagoboldt/sharelatex, but the image uploaded to index.docker.io is tiagoboldt/sharelatex-docker:sharelatex

Therefore the `docker run` command mentioned in the README doesn't work with `docker pull...` method.

Either merge this PR, or consider creating the trusted build to be `tiagoboldt/sharelatex:latest`
