### PR TITLE
add grunt migrate to start script

### DIFF
--- a/sharelatex.sh
+++ b/sharelatex.sh
@@ -37,3 +37,5 @@ SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee node /sharelatex/spelling/app.
 SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee node /sharelatex/tags/app.js >> /data/logs/tags.log 2>&1 &
 SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee node /sharelatex/track-changes/app.js >> /data/logs/track-changes.log 2>&1 &
 SHARELATEX_CONFIG=/etc/sharelatex/settings.coffee node /sharelatex/web/app.js >> /data/logs/web.log 2>&1
+
+cd /sharelatex && grunt migrate -v


### PR DESCRIPTION
Updating the container from sharelatex version 0.1.4 to 0.2.0 does not work if data is not migrated.

Calling the script on every container boot should not be an issue as grunt migrate terminates with 'noting to do' the second time it is called.