### PR TITLE
Update baseimage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+services:
+  - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
+sudo: required
 services:
   - docker
+
+script:
+  - docker build -t sharelatex-docker .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # We will stick to the official Dockerfile & Version
-FROM phusion/baseimage:0.9.16
+FROM phusion/baseimage:0.11
 
 # Update the System
 RUN apt update
 RUN apt upgrade -y
 
 # Install Node and required packages.
-RUN /usr/bin/curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
-RUN apt-get install -y build-essential wget nodejs unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-alt aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-no aspell-nr aspell-ns aspell-or aspell-pa aspell-pl aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-ta aspell-te aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu redis-server mongodb-server
+RUN /usr/bin/curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y build-essential wget nodejs unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev aspell aspell-* redis-server mongodb-server
 
 # Install QPDF dependency
 WORKDIR /opt
@@ -43,7 +43,7 @@ WORKDIR /
 RUN npm install && rm package.json
 
 WORKDIR /sharelatex
-RUN npm install && grunt install 
+RUN npm install && grunt install
 
 WORKDIR /sharelatex/web
 RUN npm install && npm install bcrypt
@@ -56,7 +56,7 @@ RUN grunt compile:bin
 WORKDIR /sharelatex
 RUN bash bin/install-services
 
-# Export 
+# Export
 EXPOSE 3000
 VOLUME /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt upgrade -y
 
 # Install Node and required packages.
 RUN /usr/bin/curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get install -y build-essential wget nodejs unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev aspell aspell-* redis-server mongodb-server
+RUN apt-get install -y build-essential wget nodejs unzip time imagemagick optipng strace nginx git python zlib1g-dev libpcre3-dev aspell aspell-* redis-server mongodb-server npm netcat
 
 # Install QPDF dependency
 WORKDIR /opt
@@ -15,15 +15,7 @@ RUN wget https://s3.amazonaws.com/sharelatex-random-files/qpdf-6.0.0.tar.gz && t
 WORKDIR /opt/qpdf-6.0.0
 RUN ./configure && make && make install && ldconfig
 
-# Clone & Install TexLive
-RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz; mkdir /install-tl-unx; tar -xvf install-tl-unx.tar.gz -C /install-tl-unx --strip-components=1
-# RUN echo "selected_scheme scheme-basic" >> /install-tl-unx/texlive.profile; /install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile
-RUN echo "selected_scheme scheme-full" >> /install-tl-unx/texlive.profile; /install-tl-unx/install-tl -profile /install-tl-unx/texlive.profile
-RUN rm -r /install-tl-unx; rm install-tl-unx.tar.gz
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/2017/bin/x86_64-linux/
-WORKDIR /usr/local/texlive/2018/bin/x86_64-linux
-RUN ./tlmgr install latexmk
-RUN ./tlmgr install texcount
+RUN apt-get install -y texlive-full
 
 # Install NPM/Grunt dependencies.
 RUN npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A docker image for running sharelatex. Still working, losely maintained, as ShareLaTex already has their own official image: https://hub.docker.com/r/sharelatex/sharelatex/
 In contrast to the official repository this version runs in a single container.
 
+[![Build Status](https://travis-ci.com/tiagoboldt/sharelatex-docker.svg?branch=master)](https://travis-ci.com/tiagoboldt/sharelatex-docker)
+
 ## Docker Image
 
 To acquire the build image from the docker's repositories execute:
@@ -21,12 +23,12 @@ To build the image from source execute:
 
 ## Execution
 
-To start the instance execute: 
-	
+To start the instance execute:
+
 	mkdir /srv/sharelatex-data
 	docker run -d -p 3000:3000 -v /srv/sharelatex-data:/data tiagoboldt/sharelatex-docker
-	
-It will be available on http://localhost:3000. Files will be kept in `/srv/sharelatex-data`. First execution might take some time to be ready. This is due to MongoDb pre-allocation.  
+
+It will be available on http://localhost:3000. Files will be kept in `/srv/sharelatex-data`. First execution might take some time to be ready. This is due to MongoDb pre-allocation.
 
 ## Create first user
 


### PR DESCRIPTION
Updates base image. Already includes changes from #38. Does not push image to docker hub, only provides the build status on the project home page. 